### PR TITLE
feat: add --shard flag for CI matrix sharding

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/alexdempster44/phpunit-parallel/internal/config"
 	"github.com/alexdempster44/phpunit-parallel/internal/output"
@@ -20,6 +21,7 @@ var (
 	configFile       string
 	runnerConfigFile string
 	teamcity         bool
+	shardFlag        string
 	runnerConfig     = config.DefaultRunner()
 	versionInfo      string
 )
@@ -85,6 +87,14 @@ var rootCmd = &cobra.Command{
 		if cmd.Flags().Changed("exclude-group") {
 			runnerConfig.ExcludeGroup, _ = cmd.Flags().GetString("exclude-group")
 		}
+		if cmd.Flags().Changed("shard") {
+			idx, total, err := parseShard(shardFlag)
+			if err != nil {
+				return fmt.Errorf("invalid --shard value: %w", err)
+			}
+			runnerConfig.ShardIndex = idx
+			runnerConfig.ShardTotal = total
+		}
 
 		return nil
 	},
@@ -140,6 +150,29 @@ func init() {
 	rootCmd.Flags().StringVar(&runnerConfig.TestSuffix, "test-suffix", runnerConfig.TestSuffix, "Suffix for test files")
 	rootCmd.Flags().StringVar(&runnerConfig.Group, "group", "", "Only run tests from the specified group(s)")
 	rootCmd.Flags().StringVar(&runnerConfig.ExcludeGroup, "exclude-group", "", "Exclude tests from the specified group(s)")
+	rootCmd.Flags().StringVar(&shardFlag, "shard", "", "Run only this shard's slice of tests, in the format X/N (e.g. 2/4). Combine with a CI matrix to fan tests across runners.")
+}
+
+func parseShard(s string) (int, int, error) {
+	parts := strings.SplitN(s, "/", 2)
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("expected format X/N, got %q", s)
+	}
+	idx, err := strconv.Atoi(strings.TrimSpace(parts[0]))
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid shard index: %w", err)
+	}
+	total, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid shard total: %w", err)
+	}
+	if total < 1 {
+		return 0, 0, fmt.Errorf("shard total must be >= 1, got %d", total)
+	}
+	if idx < 1 || idx > total {
+		return 0, 0, fmt.Errorf("shard index %d out of range [1..%d]", idx, total)
+	}
+	return idx, total, nil
 }
 
 func SetVersionInfo(version string) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -150,7 +150,7 @@ func init() {
 	rootCmd.Flags().StringVar(&runnerConfig.TestSuffix, "test-suffix", runnerConfig.TestSuffix, "Suffix for test files")
 	rootCmd.Flags().StringVar(&runnerConfig.Group, "group", "", "Only run tests from the specified group(s)")
 	rootCmd.Flags().StringVar(&runnerConfig.ExcludeGroup, "exclude-group", "", "Exclude tests from the specified group(s)")
-	rootCmd.Flags().StringVar(&shardFlag, "shard", "", "Run only this shard's slice of tests, in the format X/N (e.g. 2/4). Combine with a CI matrix to fan tests across runners.")
+	rootCmd.Flags().StringVar(&shardFlag, "shard", "", "Run only this shard's slice of tests, in the format X/N (e.g. 2/4)")
 }
 
 func parseShard(s string) (int, int, error) {

--- a/internal/config/runner.go
+++ b/internal/config/runner.go
@@ -20,6 +20,8 @@ type Runner struct {
 	Filter         string   `xml:"-"` // CLI-only, not in XML config
 	Group          string   `xml:"-"` // CLI-only, not in XML config
 	ExcludeGroup   string   `xml:"-"` // CLI-only, not in XML config
+	ShardIndex     int      `xml:"-"` // CLI-only: 1-indexed shard number, 0 = no sharding
+	ShardTotal     int      `xml:"-"` // CLI-only: total number of shards, 0 = no sharding
 }
 
 func DefaultRunner() *Runner {

--- a/internal/distributor/distributor.go
+++ b/internal/distributor/distributor.go
@@ -1,5 +1,7 @@
 package distributor
 
+import "sort"
+
 type TestFile struct {
 	Path  string
 	Suite string
@@ -55,14 +57,18 @@ func (d Distribution) GetWorkerTests(workerID int) []TestFile {
 }
 
 // Shard returns the slice of tests assigned to shardIndex (1-indexed) of shardTotal.
-// File i goes to shard (i % shardTotal) + 1, so the combination of all shards covers every
-// test exactly once with no overlap. Caller must pass tests in a stable order.
+// Tests are sorted by path for determinism, then file i goes to shard (i % shardTotal) + 1,
+// so the combination of all shards covers every test exactly once with no overlap.
 func Shard(tests []TestFile, shardIndex, shardTotal int) []TestFile {
 	if shardTotal <= 1 {
 		return tests
 	}
-	sliced := make([]TestFile, 0, len(tests)/shardTotal+1)
-	for i, t := range tests {
+	sorted := make([]TestFile, len(tests))
+	copy(sorted, tests)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Path < sorted[j].Path })
+
+	sliced := make([]TestFile, 0, (len(sorted)+shardTotal-1)/shardTotal)
+	for i, t := range sorted {
 		if i%shardTotal == shardIndex-1 {
 			sliced = append(sliced, t)
 		}

--- a/internal/distributor/distributor.go
+++ b/internal/distributor/distributor.go
@@ -53,3 +53,19 @@ func (d Distribution) GetWorkerTests(workerID int) []TestFile {
 	}
 	return d.Workers[workerID].Tests
 }
+
+// Shard returns the slice of tests assigned to shardIndex (1-indexed) of shardTotal.
+// File i goes to shard (i % shardTotal) + 1, so the combination of all shards covers every
+// test exactly once with no overlap. Caller must pass tests in a stable order.
+func Shard(tests []TestFile, shardIndex, shardTotal int) []TestFile {
+	if shardTotal <= 1 {
+		return tests
+	}
+	sliced := make([]TestFile, 0, len(tests)/shardTotal+1)
+	for i, t := range tests {
+		if i%shardTotal == shardIndex-1 {
+			sliced = append(sliced, t)
+		}
+	}
+	return sliced
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -41,6 +41,11 @@ func (r *Runner) Run() error {
 		return fmt.Errorf("failed to discover tests: %w", err)
 	}
 
+	if r.RunnerConfig.ShardTotal > 1 {
+		sort.Slice(tests, func(i, j int) bool { return tests[i].Path < tests[j].Path })
+		tests = distributor.Shard(tests, r.RunnerConfig.ShardIndex, r.RunnerConfig.ShardTotal)
+	}
+
 	dist := distributor.RoundRobin(tests, r.RunnerConfig.Workers)
 	workers := r.createWorkers(dist)
 	workerCount := len(workers)

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -42,7 +42,6 @@ func (r *Runner) Run() error {
 	}
 
 	if r.RunnerConfig.ShardTotal > 1 {
-		sort.Slice(tests, func(i, j int) bool { return tests[i].Path < tests[j].Path })
 		tests = distributor.Shard(tests, r.RunnerConfig.ShardIndex, r.RunnerConfig.ShardTotal)
 	}
 


### PR DESCRIPTION
Enabling shards so multiple CI runners can run assigned slice of the total tests, and ensuring each test runs exactly once without overlapping (--shard X/N)